### PR TITLE
Use external reference to Forge download

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,12 @@
     <center><p> Download List </center>
     <center><a href="Bee Tools v.1.1.jar" style="text-decoration:none" download> Download Latest (17KB) </a></center>
     <center><p>FORGE DOWNLOAD:</p>
-    <center><a href="forge-1.12.2-14.23.5.2847-installer-win.exe" style="text-decoration:none" download> forge-1.12.2-14.23.5.2847-installer-win.exe (4MB) </a></center>
-      <center><h2>Older Versions</h2></center>
-      <center>
-        <p>1.0</p>
+    <center><a href="https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-installer-win.exe" style="text-decoration:none" download> forge-1.12.2-14.23.5.2847-installer-win.exe (4MB) </a></center>
+	<center><h2>Older Versions</h2></center>
+    <center>
+		<p>1.0</p>
         <a href="Bee Tools.jar" style="text-decoration:none" download> Bee Tools v1.0.jar download (7KB)</a>
-      </center>
+    </center>
   </div>
   </body>
 </html>


### PR DESCRIPTION
Saw your mod on the Minecraft Forum. Just wanted to fix something on your website. Following Forge's license, you're not allowed to redistribute copies of Forge installers or libraries, so all I did to fix this problem is update your Forge download link to an official link rather than linking to a copied installer stored on your website.